### PR TITLE
Added a 'generate_hex_name' method

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'frosty_meadow'
-  s.version     = '0.0.5'
+  s.version     = '1.0.0'
   s.summary     = "Random server name generator!"
   s.description = "This gem will generate a random name for your server, much in the way Heroku does."
   s.authors     = ["Andy Hamilton"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Custom adjectives/nouns may also be used:
 
 	FrostyMeadow.generate(:adjectives => ["beautiful", "amazing", "awesome"], :nouns => ["world", "earth", "globe"]) #=> amazing world
 
+If you are using this to generate server names similar to how heroku does it, then the `generate_hex_name` method will provide you with one formatted similarly :
+
+	FrostyMeadow.generate_hex_name #=> billowing-snowflake-41aa3
+
 Pull requests
 ---------------
 Pull requests are more than welcome. To test, just use rspec: `bundle exec rspec`

--- a/lib/frosty_meadow.rb
+++ b/lib/frosty_meadow.rb
@@ -32,4 +32,8 @@ class FrostyMeadow
 
 		return words
 	end
+
+	def self.hex_string length=5
+		((0..length).map{rand(256).chr}*"").unpack("H*")[0][0,length]
+	end
 end

--- a/lib/frosty_meadow.rb
+++ b/lib/frosty_meadow.rb
@@ -33,6 +33,12 @@ class FrostyMeadow
 		return words
 	end
 
+	def self.generate_hex_name
+		generated_string = self.generate(:separator => '-')
+
+		return "#{generated_string}-#{self.hex_string}"
+	end
+
 	def self.hex_string length=5
 		((0..length).map{rand(256).chr}*"").unpack("H*")[0][0,length]
 	end

--- a/spec/frosty_meadow_spec.rb
+++ b/spec/frosty_meadow_spec.rb
@@ -19,4 +19,20 @@ describe FrostyMeadow do
 			FrostyMeadow.generate.split.size.should eql 2
 		end
 	end
+
+	describe "#hex_string" do
+		it "generates a 5 letter hexadecimal string by default" do
+			string = FrostyMeadow.hex_string
+
+			string.should =~ /^[0-9A-F]+$/i
+			string.length.should eql 5
+		end
+
+		it "generates a hexadecimal string with the provided length" do
+			FrostyMeadow.hex_string(1).length.should eql 1
+			FrostyMeadow.hex_string(2).length.should eql 2
+			FrostyMeadow.hex_string(3).length.should eql 3
+			FrostyMeadow.hex_string(100).length.should eql 100 
+		end
+	end
 end

--- a/spec/frosty_meadow_spec.rb
+++ b/spec/frosty_meadow_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe FrostyMeadow do
+
+	before :each do
+		@hexadecimal_regex = /^[0-9A-F]+$/i
+	end
+
 	describe "#generate" do
 		it "generates a random string" do
 			FrostyMeadow.generate(:adjectives => ["hello"], :nouns => ["world"]).should eql 'hello world'
@@ -20,11 +25,25 @@ describe FrostyMeadow do
 		end
 	end
 
+	describe "#generate_hex_name" do
+		it "should generate a string consisting of 3 strings seperated by dashes" do
+			FrostyMeadow.generate_hex_name.split('-').size.should eql 3
+		end
+
+		it "generates a dashed string where the last word is hexadecimal" do
+			FrostyMeadow.generate_hex_name.split('-').last.should =~ @hexadecimal_regex
+		end
+
+		it "generates a dashed string where the last word is 5 characters long" do
+			FrostyMeadow.generate_hex_name.split('-').last.length.should eql 5
+		end
+	end
+
 	describe "#hex_string" do
 		it "generates a 5 letter hexadecimal string by default" do
 			string = FrostyMeadow.hex_string
 
-			string.should =~ /^[0-9A-F]+$/i
+			string.should =~ @hexadecimal_regex
 			string.length.should eql 5
 		end
 


### PR DESCRIPTION
I've added a new method called `generate_hex_name` that will generate a heroku-esque formatted name such as `sparkling-field-9e6ef`
